### PR TITLE
add note about required qt 5 version

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -4,6 +4,8 @@ VeriCoin-qt: Qt5 GUI for VeriCoin
 Build instructions
 ===================
 
+Building your own VeriCoin GUI requires Qt version 5.2 or newer.
+
 Debian
 -------
 


### PR DESCRIPTION
I was trying to build the wallet on a fairly old version of ubuntu (13.10) and the build failed with:

```
In file included from src/qt/updatedialog.cpp:2:0:
build/ui_updatedialog.h: In member function ‘void Ui_UpdateDialog::retranslateUi(QDialog*)’:
build/ui_updatedialog.h:128:22: error: ‘class QTextEdit’ has no member named ‘setPlaceholderText’
         description->setPlaceholderText(QString());
                      ^
make: *** [build/updatedialog.o] Error 1
```

Turns out `placeholderText` was introduced in Qt 5.2 (http://doc.qt.io/qt-5/qtextedit.html#placeholderText-prop).

This PR adds some documentation about this requirement.
