### PR TITLE
Added createrawtext RPC command

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -297,6 +297,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listunspent",            &listunspent,            false,  false },
     { "getrawtransaction",      &getrawtransaction,      false,  false },
     { "createrawtransaction",   &createrawtransaction,   false,  false },
+    { "createrawtext",          &createrawtext,          false,  false },
     { "decoderawtransaction",   &decoderawtransaction,   false,  false },
     { "decodescript",           &decodescript,           false,  false },
     { "signrawtransaction",     &signrawtransaction,     false,  false },
@@ -1242,6 +1243,8 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "getrawtransaction"      && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "createrawtransaction"   && n > 0) ConvertTo<Array>(params[0]);
     if (strMethod == "createrawtransaction"   && n > 1) ConvertTo<Object>(params[1]);
+    if (strMethod == "createrawtext"          && n > 0) ConvertTo<Array>(params[0]);
+    if (strMethod == "createrawtext"          && n > 1) ConvertTo<Object>(params[1]);
     if (strMethod == "signrawtransaction"     && n > 1) ConvertTo<Array>(params[1], true);
     if (strMethod == "signrawtransaction"     && n > 2) ConvertTo<Array>(params[2], true);
     if (strMethod == "keypoolrefill"          && n > 0) ConvertTo<boost::int64_t>(params[0]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1245,6 +1245,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "createrawtransaction"   && n > 1) ConvertTo<Object>(params[1]);
     if (strMethod == "createrawtext"          && n > 0) ConvertTo<Array>(params[0]);
     if (strMethod == "createrawtext"          && n > 1) ConvertTo<Object>(params[1]);
+    if (strMethod == "createrawtext"          && n > 2) ConvertTo<Object>(params[2]);
     if (strMethod == "signrawtransaction"     && n > 1) ConvertTo<Array>(params[1], true);
     if (strMethod == "signrawtransaction"     && n > 2) ConvertTo<Array>(params[2], true);
     if (strMethod == "keypoolrefill"          && n > 0) ConvertTo<boost::int64_t>(params[0]);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -207,6 +207,7 @@ extern json_spirit::Value getnewpubkey(const json_spirit::Array& params, bool fH
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value createrawtransaction(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value createrawtext(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value decoderawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value decodescript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value signrawtransaction(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -302,7 +302,9 @@ Value createrawtext(const Array& params, bool fHelp)
             "sending to given address(es).\n"
             "Returns hex-encoded raw transaction.\n"
             "Note that the transaction's inputs are not signed, and\n"
-            "it is not stored in the wallet or transmitted to the network.");
+            "it is not stored in the wallet or transmitted to the network.\n"
+            "The message will be added as an OP_RETRUN \n"
+            "The maximum message size is 80 bytes");
 
     RPCTypeCheck(params, list_of(array_type)(obj_type)(obj_type));
 
@@ -311,9 +313,11 @@ Value createrawtext(const Array& params, bool fHelp)
     Object message_o = params[2].get_obj();
     Value  message_v = find_value(message_o, "message");
     string message = message_v.get_str();
-    CTransaction rawTx;
 
-//    printf("Help I'm trapped in a VRC wallet %s \n",message);
+    if (message.size() > 80)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Your Message is longer then 80 bytes");
+
+    CTransaction rawTx;
 
 
     BOOST_FOREACH(Value& input, inputs)
@@ -356,6 +360,8 @@ Value createrawtext(const Array& params, bool fHelp)
         CTxOut out(nAmount, scriptPubKey);
         rawTx.vout.push_back(out);
     }
+
+
 
     CScript OpRet;
     OpRet.push_back(0x6a);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -304,7 +304,7 @@ Value createrawtext(const Array& params, bool fHelp)
             "Note that the transaction's inputs are not signed, and\n"
             "it is not stored in the wallet or transmitted to the network.\n"
             "The message will be added as an OP_RETRUN \n"
-            "The maximum message size is 80 bytes");
+            "The maximum message size is 1 kb");
 
     RPCTypeCheck(params, list_of(array_type)(obj_type)(obj_type));
 
@@ -314,8 +314,8 @@ Value createrawtext(const Array& params, bool fHelp)
     Value  message_v = find_value(message_o, "message");
     string message = message_v.get_str();
 
-    if (message.size() > 80)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Your Message is longer then 80 bytes");
+    if (message.size() > 1000)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Your Message is longer then 1 kb");
 
     CTransaction rawTx;
 


### PR DESCRIPTION
I've added a new createrawtext RPC command that takes inputs in JSON format and creates a valid OP_RETURN transaction. 