### PR TITLE
Add instructions on how to build deps on RHEL based distros.

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -61,6 +61,12 @@ Versions used in this release:
  Boost         1.55
  miniupnpc     1.9
 
+
+Dependency Build Instructions: Fedora & RHEL/CentOS
+---------------------------------------------------
+yum install libcurl-devel miniupnpc-devel libdb-cxx-devel openssl-devel boost-devel
+
+
 Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 sudo apt-get install build-essential


### PR DESCRIPTION
This was tested on Fedora 24. It uses the `yum` as opposed to `dnf` just for backwards compatibility with RHEL/CentOS