### PR TITLE
Fix block wth too little proof-of-stake error 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1118,7 +1118,10 @@ unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime)
 //
 unsigned int ComputeMinStake(unsigned int nBase, int64_t nTime, unsigned int nBlockTime)
 {
-    return ComputeMaxBits(bnProofOfStakeLimit, nBase, nTime);
+    // With current parameters, Vericoin diff can drop very quickly, so there
+    // is little point in enforcing a minimum difficulty other than the global
+    // min diff
+    return bnProofOfStakeLimit.GetCompact();
 }
 
 


### PR DESCRIPTION
Fix for incorrect minimum proof of stake difficulty calculation
ComputeMinStake incorrectly assumed that difficulty can only drop 1/2 per day, while for Vericoin it can drop much faster.
The function now simply returns the global minimum difficulty.
This should be redone for PoST 2.0 where difficulty adjustment will likely be slower.